### PR TITLE
fix javadoc unknown character errors causing javadoc gradle task to fail

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ repositories {
 if (JavaVersion.current().isJava8Compatible()) {
     allprojects {
         tasks.withType(Javadoc) {
+            options.addStringOption("encoding", "UTF-8")
             options.addStringOption('Xdoclint:none', '-quiet')
         }
     }


### PR DESCRIPTION
gradle assemble task depends on javadoc which fails due to unknown characters. The fix is to set the encoding with a parameter to the javadoc tool.
Solution via http://stackoverflow.com/questions/25912190/how-to-set-an-encoding-for-the-javadoc-in-gradle