### PR TITLE
AWT dependencies removed from clean-room text extrude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /bin/
 /.classpath
 /.project
+/*.stl

--- a/.settings/.gitignore
+++ b/.settings/.gitignore
@@ -1,0 +1,1 @@
+/org.eclipse.buildship.core.prefs

--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ dependencies {
     
     testCompile group: 'junit', name: 'junit', version: '4.+'
 
-    compile group: 'eu.mihosoft.ext.org.fxyz', name: 'extfxyz', version: '0.4'
-    compile group: 'eu.mihosoft.ext.org.fxyz', name: 'extfxyz', version: '0.4', classifier: 'sources'
+    //compile group: 'eu.mihosoft.ext.org.fxyz', name: 'extfxyz', version: '0.4'
+    //compile group: 'eu.mihosoft.ext.org.fxyz', name: 'extfxyz', version: '0.4', classifier: 'sources'
     compile group: 'java3d', name: 'vecmath', version: '1.3.1'
     compile 'org.slf4j:slf4j-simple:1.6.1'
 }

--- a/src/main/java/eu/mihosoft/vrl/v3d/CSG.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/CSG.java
@@ -105,7 +105,243 @@ public class CSG {
     private CSG() {
         storage = new PropertyStorage();
     }
-
+	/**
+     * To z min.
+     *
+     * @param target the target
+     * @return the csg
+     */
+    public CSG toZMin(CSG target){
+		return this.transformed(new Transform().translateZ(-target.getBounds().getMin().z));
+	}
+	
+	/**
+	 * To z max.
+	 *
+	 * @param target the target
+	 * @return the csg
+	 */
+	public CSG toZMax(CSG target){
+		return this.transformed(new Transform().translateZ(-target.getBounds().getMax().z));
+	}
+	
+	/**
+	 * To x min.
+	 *
+	 * @param target the target
+	 * @return the csg
+	 */
+	public CSG toXMin(CSG target){
+		return this.transformed(new Transform().translateX(-target.getBounds().getMin().x));
+	}
+	
+	/**
+	 * To x max.
+	 *
+	 * @param target the target
+	 * @return the csg
+	 */
+	public CSG toXMax(CSG target){
+		return this.transformed(new Transform().translateX(-target.getBounds().getMax().x));
+	}
+	
+	/**
+	 * To y min.
+	 *
+	 * @param target the target
+	 * @return the csg
+	 */
+	public CSG toYMin(CSG target){
+		return this.transformed(new Transform().translateY(-target.getBounds().getMin().y));
+	}
+	
+	/**
+	 * To y max.
+	 *
+	 * @param target the target
+	 * @return the csg
+	 */
+	public CSG toYMax(CSG target){
+		return this.transformed(new Transform().translateY(-target.getBounds().getMax().y));
+	}
+	
+	/**
+	 * To z min.
+	 *
+	 * @return the csg
+	 */
+	public CSG toZMin(){
+		return toZMin(this);
+	}
+	
+	/**
+	 * To z max.
+	 *
+	 * @return the csg
+	 */
+	public CSG toZMax(){
+		return toZMax(this);
+	}
+	
+	/**
+	 * To x min.
+	 *
+	 * @return the csg
+	 */
+	public CSG toXMin(){
+		return toXMin(this);
+	}
+	
+	/**
+	 * To x max.
+	 *
+	 * @return the csg
+	 */
+	public CSG toXMax(){
+		return toXMax(this);
+	}
+	
+	/**
+	 * To y min.
+	 *
+	 * @return the csg
+	 */
+	public CSG toYMin(){
+		return toYMin(this);
+	}
+	
+	/**
+	 * To y max.
+	 *
+	 * @return the csg
+	 */
+	public CSG toYMax(){
+		return toYMax(this);
+	}
+	
+	public CSG move(double x, double y, double z){
+		return 	movex(x)
+				.movey(y)
+				.movez(z);
+	}
+	
+	public CSG move(double [] posVector){
+		return move(posVector[0],posVector[1],posVector[2]);
+	}
+	
+	/**
+	 * Movey.
+	 *
+	 * @param howFarToMove the how far to move
+	 * @return the csg
+	 */
+	//Helper/wrapper functions for movement
+	public CSG movey(double howFarToMove){
+		return this.transformed(Transform.unity().translateY(howFarToMove));
+	}
+	
+	/**
+	 * Movez.
+	 *
+	 * @param howFarToMove the how far to move
+	 * @return the csg
+	 */
+	public CSG movez(double howFarToMove ){
+		return this.transformed(Transform.unity().translateZ(howFarToMove));
+	}
+	
+	/**
+	 * Movex.
+	 *
+	 * @param howFarToMove the how far to move
+	 * @return the csg
+	 */
+	public CSG movex(double howFarToMove ){
+		return this.transformed(Transform.unity().translateX(howFarToMove));
+	}
+	
+	public CSG rot(double x, double y, double z){
+		return 	rotx(x)
+				.roty(y)
+				.rotz(z);
+	}
+	
+	public CSG rot(double [] posVector){
+		return rot(posVector[0],posVector[1],posVector[2]);
+	}
+	
+	
+	/**
+	 * Rotz.
+	 *
+	 * @param degreesToRotate the degrees to rotate
+	 * @return the csg
+	 */
+	//Rotation function, rotates the object
+	public CSG rotz(double degreesToRotate ){
+		return this.transformed(new Transform().rotZ(degreesToRotate));
+	}
+	
+	/**
+	 * Roty.
+	 *
+	 * @param degreesToRotate the degrees to rotate
+	 * @return the csg
+	 */
+	public CSG roty(double degreesToRotate ){
+		return this.transformed(new Transform().rotY(degreesToRotate));
+	}
+	
+	/**
+	 * Rotx.
+	 *
+	 * @param degreesToRotate the degrees to rotate
+	 * @return the csg
+	 */
+	public CSG rotx(double degreesToRotate ){
+		return this.transformed(new Transform().rotX(degreesToRotate));
+	}
+	
+	/**
+	 * Scalez.
+	 *
+	 * @param scaleValue the scale value
+	 * @return the csg
+	 */
+	//Scale function, scales the object
+	public CSG scalez(double scaleValue ){
+		return this.transformed(new Transform().scaleZ(scaleValue));
+	}
+	
+	/**
+	 * Scaley.
+	 *
+	 * @param scaleValue the scale value
+	 * @return the csg
+	 */
+	public CSG scaley(double scaleValue ){
+		return this.transformed(new Transform().scaleY(scaleValue));
+	}
+	
+	/**
+	 * Scalex.
+	 *
+	 * @param scaleValue the scale value
+	 * @return the csg
+	 */
+	public CSG scalex(double scaleValue ){
+		return this.transformed(new Transform().scaleX(scaleValue));
+	}
+	
+	/**
+	 * Scale.
+	 *
+	 * @param scaleValue the scale value
+	 * @return the csg
+	 */
+	public CSG scale(double scaleValue ){
+		return this.transformed(new Transform().scale(scaleValue));	
+	}
     /**
      * Constructs a CSG from a list of {@link Polygon} instances.
      *

--- a/src/main/java/eu/mihosoft/vrl/v3d/CSG.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/CSG.java
@@ -100,6 +100,7 @@ public class CSG {
     private static OptType defaultOptType = OptType.NONE;
     private OptType optType = null;
     private PropertyStorage storage;
+	private Bounds bounds;
 
     private CSG() {
         storage = new PropertyStorage();
@@ -1100,13 +1101,16 @@ public class CSG {
 
     /**
      * Returns the bounds of this csg.
+     * SIDE EFFECT bounds is created and simply returned if existing
      *
      * @return bouds of this csg
      */
     public Bounds getBounds() {
-
-        if (polygons.isEmpty()) {
-            return new Bounds(Vector3d.ZERO, Vector3d.ZERO);
+        if(bounds!=null)
+        	return bounds;
+        if (getPolygons().isEmpty()) {
+        	bounds=  new Bounds(Vector3d.ZERO, Vector3d.ZERO);
+        	return bounds;
         }
 
         double minX = Double.POSITIVE_INFINITY;
@@ -1147,9 +1151,52 @@ public class CSG {
 
         } // end for polygon
 
-        return new Bounds(
+        bounds= new Bounds(
                 new Vector3d(minX, minY, minZ),
                 new Vector3d(maxX, maxY, maxZ));
+        return bounds;
+    }
+    /**
+     * Helper function wrapping bounding box values
+     * @return MaxX
+     */
+    public double getMaxX(){
+    	return getBounds().getMax().x;
+    }
+    /**
+     * Helper function wrapping bounding box values
+     * @return MaxY
+     */
+    public double getMaxY(){
+    	return getBounds().getMax().y;
+    }
+    /**
+     * Helper function wrapping bounding box values
+     * @return MaxZ
+     */
+    public double getMaxZ(){
+    	return getBounds().getMax().z;
+    }
+    /**
+     * Helper function wrapping bounding box values
+     * @return MinX
+     */
+    public double getMinX(){
+    	return getBounds().getMin().x;
+    }
+    /**
+     * Helper function wrapping bounding box values
+     * @return MinY
+     */
+    public double getMinY(){
+    	return getBounds().getMin().y;
+    }
+    /**
+     * Helper function wrapping bounding box values
+     * @return tMinZ
+     */
+    public double getMinZ(){
+    	return getBounds().getMin().z;
     }
 
     /**
@@ -1179,5 +1226,29 @@ public class CSG {
         POLYGON_BOUND,
         NONE
     }
+    /**
+     * A test to see if 2 CSG's are touching. The fast-return is a bounding box check
+     * If bounding boxes overlap, then an intersection is performed and the existance of an interscting object is returned
+     * @param incoming
+     * @return
+     */
+	public boolean touching(CSG incoming){
+		// Fast bounding box overlap check, quick fail if not intersecting bounding boxes
+		if( this.getMaxX()>incoming.getMinX() &&
+			this.getMinX()<incoming.getMaxX() &&	
+			this.getMaxY()>incoming.getMinY() &&
+			this.getMinY()<incoming.getMaxY() &&
+			this.getMaxZ()>incoming.getMinZ() &&
+			this.getMinZ()<incoming.getMaxZ() 
+				){
+			//Run a full intersection
+			CSG inter = this.intersect(incoming);
+			if(inter.getPolygons().size() >0 ){
+				// intersection success
+				return true;
+			}
+		}		
+		return false;
+	}
 
 }

--- a/src/main/java/eu/mihosoft/vrl/v3d/Text3d.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Text3d.java
@@ -33,11 +33,9 @@
  */
 package eu.mihosoft.vrl.v3d;
 
-import java.lang.reflect.Field;
+import java.awt.Font;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 /**
  * 3d text primitive. 
  * 
@@ -46,18 +44,7 @@ import java.util.logging.Logger;
 public class Text3d implements Primitive {
 
     private final PropertyStorage properties = new PropertyStorage();
-
-    private final String text;
-    private String fontName;
-    private double size;
-    private double depth;
-    private boolean noCenter;
-
-    // 08.11.2016
-    // TODO report bug to FXyz authors
-    // factor by which we multiply text generation to minimize rendering errors
-    double scaleFactor = 100;
-
+    ArrayList<CSG> letters;
     /**
      * Constructor.
      * 
@@ -86,23 +73,22 @@ public class Text3d implements Primitive {
      * @param depth text depth (z thickness)
      */
     public Text3d(String text, String fontName, double fontSize, double depth) {
-        this.text = text;
-        this.fontName = fontName;
-        this.size = fontSize;
-        this.depth = depth;
 
-        // scaled size and height (see scaleFactor docs)
-        int realSize = (int) (fontSize * scaleFactor);
-        double realHeight = depth * scaleFactor;
-
-//        t3dMesh = new Text3DMesh(
-//                text, fontName, realSize, false, realHeight, 0, 0);
+    	Font font = new Font(fontName,  Font.PLAIN, (int) fontSize);
+    	letters = TextExtrude.text( depth,  text,  font);
+    	for (int i=0;i<letters.size();i++){
+    		letters.set(i, letters.get(i)
+    				.rotx(180)
+    				.toZMin()
+    				);
+    	}
+    	
+    	
     }
 
     @Override
     public List<Polygon> toPolygons() {
-        //return new MeshRetriever(this).toCSG(noCenter).getPolygons();
-    	return null;
+    	return letters.get(0).union(letters).getPolygons();
     }
 
     @Override
@@ -111,84 +97,7 @@ public class Text3d implements Primitive {
     }
 
     public Text3d noCenter() {
-        this.noCenter = true;
-
         return this;
     }
 
 }
-
-//class MeshRetriever {
-//
-//    private final Text3d t3dMesh;
-//
-//    public MeshRetriever(Text3d t3dMesh) {
-//        this.t3dMesh = t3dMesh;
-//    }
-//
-//    public CSG toCSG(boolean noCenter) {
-//        List<CSG> csgs = new ArrayList<>();
-//
-//        CSG result = null;
-//
-//        List<TexturedMesh> meshes = getMeshes();
-//
-//        for (int i = 0; i < meshes.size(); i++) {
-//
-//            TexturedMesh mesh = meshes.get(i);
-//
-//            CSG csg = MeshUtils.mesh2CSG(mesh);
-//
-//            double xTransform = mesh.getTransforms().stream().
-//                    mapToDouble(tr -> tr.getTx()).sum();
-//
-//            csg = csg.transformed(Transform.unity().translateX(xTransform));
-//
-//            // rescale final mesh (see scaleFactor docs)
-//            double xScale = 1.0 / t3dMesh.scaleFactor;
-//            csg = csg.transformed(Transform.unity().
-//                    scale(xScale, -xScale, xScale));
-//
-//            if (result == null) {
-//                result = csg;
-//            } else {
-//                result = result.dumbUnion(csg);
-//            }
-//        }
-//
-//        if (!noCenter) {
-//            result = result.transformed(
-//                    Transform.unity().translate(
-//                            -result.getBounds().getBounds().x * 0.5,
-//                            -result.getBounds().getBounds().y * 0.5,
-//                            -result.getBounds().getBounds().z * 0.5)
-//            );
-//        }
-//
-//        return result;
-//    }
-//
-//    public List<TexturedMesh> getMeshes() {
-//        try {
-//            Field field = Text3DMesh.class.getDeclaredField("meshes");
-//
-//            field.setAccessible(true);
-//
-//            return (List<TexturedMesh>) field.get(t3dMesh.t3dMesh);
-//        } catch (NoSuchFieldException ex) {
-//            Logger.getLogger(MeshRetriever.class.getName()).
-//                    log(Level.SEVERE, null, ex);
-//        } catch (SecurityException ex) {
-//            Logger.getLogger(MeshRetriever.class.getName()).
-//                    log(Level.SEVERE, null, ex);
-//        } catch (IllegalArgumentException ex) {
-//            Logger.getLogger(MeshRetriever.class.getName()).
-//                    log(Level.SEVERE, null, ex);
-//        } catch (IllegalAccessException ex) {
-//            Logger.getLogger(MeshRetriever.class.getName()).
-//                    log(Level.SEVERE, null, ex);
-//        }
-//
-//        return null;
-//    }
-//}

--- a/src/main/java/eu/mihosoft/vrl/v3d/Text3d.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Text3d.java
@@ -38,10 +38,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.fxyz.shapes.primitives.Text3DMesh;
-import org.fxyz.shapes.primitives.TexturedMesh;
-import org.fxyz.utils.MeshUtils;
-
 /**
  * 3d text primitive. 
  * 
@@ -55,7 +51,6 @@ public class Text3d implements Primitive {
     private String fontName;
     private double size;
     private double depth;
-    Text3DMesh t3dMesh;
     private boolean noCenter;
 
     // 08.11.2016
@@ -100,13 +95,14 @@ public class Text3d implements Primitive {
         int realSize = (int) (fontSize * scaleFactor);
         double realHeight = depth * scaleFactor;
 
-        t3dMesh = new Text3DMesh(
-                text, fontName, realSize, false, realHeight, 0, 0);
+//        t3dMesh = new Text3DMesh(
+//                text, fontName, realSize, false, realHeight, 0, 0);
     }
 
     @Override
     public List<Polygon> toPolygons() {
-        return new MeshRetriever(this).toCSG(noCenter).getPolygons();
+        //return new MeshRetriever(this).toCSG(noCenter).getPolygons();
+    	return null;
     }
 
     @Override
@@ -122,77 +118,77 @@ public class Text3d implements Primitive {
 
 }
 
-class MeshRetriever {
-
-    private final Text3d t3dMesh;
-
-    public MeshRetriever(Text3d t3dMesh) {
-        this.t3dMesh = t3dMesh;
-    }
-
-    public CSG toCSG(boolean noCenter) {
-        List<CSG> csgs = new ArrayList<>();
-
-        CSG result = null;
-
-        List<TexturedMesh> meshes = getMeshes();
-
-        for (int i = 0; i < meshes.size(); i++) {
-
-            TexturedMesh mesh = meshes.get(i);
-
-            CSG csg = MeshUtils.mesh2CSG(mesh);
-
-            double xTransform = mesh.getTransforms().stream().
-                    mapToDouble(tr -> tr.getTx()).sum();
-
-            csg = csg.transformed(Transform.unity().translateX(xTransform));
-
-            // rescale final mesh (see scaleFactor docs)
-            double xScale = 1.0 / t3dMesh.scaleFactor;
-            csg = csg.transformed(Transform.unity().
-                    scale(xScale, -xScale, xScale));
-
-            if (result == null) {
-                result = csg;
-            } else {
-                result = result.dumbUnion(csg);
-            }
-        }
-
-        if (!noCenter) {
-            result = result.transformed(
-                    Transform.unity().translate(
-                            -result.getBounds().getBounds().x * 0.5,
-                            -result.getBounds().getBounds().y * 0.5,
-                            -result.getBounds().getBounds().z * 0.5)
-            );
-        }
-
-        return result;
-    }
-
-    public List<TexturedMesh> getMeshes() {
-        try {
-            Field field = Text3DMesh.class.getDeclaredField("meshes");
-
-            field.setAccessible(true);
-
-            return (List<TexturedMesh>) field.get(t3dMesh.t3dMesh);
-        } catch (NoSuchFieldException ex) {
-            Logger.getLogger(MeshRetriever.class.getName()).
-                    log(Level.SEVERE, null, ex);
-        } catch (SecurityException ex) {
-            Logger.getLogger(MeshRetriever.class.getName()).
-                    log(Level.SEVERE, null, ex);
-        } catch (IllegalArgumentException ex) {
-            Logger.getLogger(MeshRetriever.class.getName()).
-                    log(Level.SEVERE, null, ex);
-        } catch (IllegalAccessException ex) {
-            Logger.getLogger(MeshRetriever.class.getName()).
-                    log(Level.SEVERE, null, ex);
-        }
-
-        return null;
-    }
-}
+//class MeshRetriever {
+//
+//    private final Text3d t3dMesh;
+//
+//    public MeshRetriever(Text3d t3dMesh) {
+//        this.t3dMesh = t3dMesh;
+//    }
+//
+//    public CSG toCSG(boolean noCenter) {
+//        List<CSG> csgs = new ArrayList<>();
+//
+//        CSG result = null;
+//
+//        List<TexturedMesh> meshes = getMeshes();
+//
+//        for (int i = 0; i < meshes.size(); i++) {
+//
+//            TexturedMesh mesh = meshes.get(i);
+//
+//            CSG csg = MeshUtils.mesh2CSG(mesh);
+//
+//            double xTransform = mesh.getTransforms().stream().
+//                    mapToDouble(tr -> tr.getTx()).sum();
+//
+//            csg = csg.transformed(Transform.unity().translateX(xTransform));
+//
+//            // rescale final mesh (see scaleFactor docs)
+//            double xScale = 1.0 / t3dMesh.scaleFactor;
+//            csg = csg.transformed(Transform.unity().
+//                    scale(xScale, -xScale, xScale));
+//
+//            if (result == null) {
+//                result = csg;
+//            } else {
+//                result = result.dumbUnion(csg);
+//            }
+//        }
+//
+//        if (!noCenter) {
+//            result = result.transformed(
+//                    Transform.unity().translate(
+//                            -result.getBounds().getBounds().x * 0.5,
+//                            -result.getBounds().getBounds().y * 0.5,
+//                            -result.getBounds().getBounds().z * 0.5)
+//            );
+//        }
+//
+//        return result;
+//    }
+//
+//    public List<TexturedMesh> getMeshes() {
+//        try {
+//            Field field = Text3DMesh.class.getDeclaredField("meshes");
+//
+//            field.setAccessible(true);
+//
+//            return (List<TexturedMesh>) field.get(t3dMesh.t3dMesh);
+//        } catch (NoSuchFieldException ex) {
+//            Logger.getLogger(MeshRetriever.class.getName()).
+//                    log(Level.SEVERE, null, ex);
+//        } catch (SecurityException ex) {
+//            Logger.getLogger(MeshRetriever.class.getName()).
+//                    log(Level.SEVERE, null, ex);
+//        } catch (IllegalArgumentException ex) {
+//            Logger.getLogger(MeshRetriever.class.getName()).
+//                    log(Level.SEVERE, null, ex);
+//        } catch (IllegalAccessException ex) {
+//            Logger.getLogger(MeshRetriever.class.getName()).
+//                    log(Level.SEVERE, null, ex);
+//        }
+//
+//        return null;
+//    }
+//}

--- a/src/main/java/eu/mihosoft/vrl/v3d/Text3d.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Text3d.java
@@ -33,9 +33,10 @@
  */
 package eu.mihosoft.vrl.v3d;
 
-import java.awt.Font;
 import java.util.ArrayList;
 import java.util.List;
+
+import javafx.scene.text.Font;
 /**
  * 3d text primitive. 
  * 
@@ -74,7 +75,7 @@ public class Text3d implements Primitive {
      */
     public Text3d(String text, String fontName, double fontSize, double depth) {
 
-    	Font font = new Font(fontName,  Font.PLAIN, (int) fontSize);
+    	Font font = new Font(fontName,  (int) fontSize);
     	letters = TextExtrude.text( depth,  text,  font);
     	for (int i=0;i<letters.size();i++){
     		letters.set(i, letters.get(i)

--- a/src/main/java/eu/mihosoft/vrl/v3d/TextExtrude.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/TextExtrude.java
@@ -1,0 +1,181 @@
+package eu.mihosoft.vrl.v3d;
+
+import java.awt.Font;
+import java.awt.GraphicsEnvironment;
+import java.awt.Shape;
+import java.awt.font.FontRenderContext;
+import java.awt.font.TextLayout;
+import java.awt.geom.PathIterator;
+import java.util.ArrayList;
+
+// TODO: Auto-generated Javadoc
+/**
+ * The Class Text.
+ */
+
+public class TextExtrude {
+	private static final String default_font ="FreeSerif" ;
+	
+    /**
+     * Extrudes the specified path (convex or concave polygon without holes or
+     * intersections, specified in CCW) into the specified direction.
+     *
+     * @param dir direction of extrusion
+     * @param text text
+     * @param font font configuration of the text
+     *
+     * @return a CSG object that consists of the extruded polygon
+     */
+    public static ArrayList<CSG> text(double dir, String text, Font font) {
+
+    	String default_font ="FreeSerif" ;
+    	String [] fonts = GraphicsEnvironment
+        					.getLocalGraphicsEnvironment()
+        					.getAvailableFontFamilyNames();
+        	
+        	boolean found = false;
+        	for(String f: fonts){
+        		if(f.contentEquals(font.getFontName())){
+        			found=true;
+        			
+        		}
+        	}
+        	if(! found){
+        		for(String f: fonts){
+    	    		
+        			System.out.println( f);
+    	    		
+    	    	}
+        		System.out.println("Font not found! "+font.getFontName() +" using "+default_font);
+        		font = new Font(default_font, font.getStyle(), font.getSize());
+        	}
+    	FontRenderContext frc = new FontRenderContext(null,(boolean)true,(boolean)true);
+    	TextLayout textLayout = new TextLayout(text, font, frc);
+    	Shape s = textLayout.getOutline(null);
+    	
+    	PathIterator pi = s.getPathIterator(null);
+    	ArrayList<Vector3d> points = new ArrayList<Vector3d>();
+    	
+    	CSG stringOut = new Sphere(2).toCSG();
+    	int connectorDepth = 10;
+    	
+    	float [] coords = new float[6];
+    	float [] start = new float[6];
+    	
+    	ArrayList<CSG> sections = new ArrayList<CSG>();
+    	ArrayList<CSG> holes = new ArrayList<CSG>();
+    	
+    	float tmp=0,tmp1=0;
+    	//BowlerStudioController.setCsg(null,null);
+    	  while(pi.isDone() == (boolean)false  ) {
+    		  	coords = new float[6];
+    	        int type = pi.currentSegment(coords);
+    	        switch(type) {
+    	        case PathIterator.SEG_CLOSE:
+    				//points.add(new Vector3d(tmp, tmp1 ,0));
+    				points.add(new Vector3d(start[0], start[1],0));
+    				
+    				if(points.size()>3){
+    					//println "Adding "+points
+    					try{
+    						//println "{"
+    						for(Vector3d v:points){
+    							//Cube nl= new Cube(1);
+    							//nl.setCenter(v);
+    							//BowlerStudioController.addCsg(nl.toCSG());
+    							//ThreadUtil.wait(200)
+    							//println "new Vector3d("+v.x+","+v.y+","+v.z+"),"
+    						}
+    						points.remove(points.size()-1);
+    						points.remove(points.size()-1);
+    						boolean hole = !Extrude.isCCW(Polygon.fromPoints(points));
+    						CSG newLetter = Extrude.points(new Vector3d(0, 0, connectorDepth), points);
+    						//ThreadUtil.wait(5000)
+    						//Color c =new Color(Math.random(),Math.random(),Math.random(),1);
+    						//newLetter.setColor(c);
+    						if(!hole)
+    							sections.add(newLetter);
+    						else
+    							holes.add(newLetter);
+    						//ThreadUtil.wait(10)
+    						//stringOut = new Sphere(2).toCSG();
+    						//return stringOut;
+    					}catch(NullPointerException e){
+    						e.printStackTrace();
+    					}
+    				}
+    	            points = new ArrayList<Vector3d>();
+    	            break;
+    			case PathIterator.SEG_QUADTO:
+    				//println "SEG_QUADTO from ( "+coords[0]+" , "+coords[1]+" ) to ( "+coords[2]+" , "+coords[3]+" )";
+    				for(float t=0.05f;t<=1.0f;t+=0.05f) {
+    					//(1-t)²*P0 + 2t*(1-t)*P1 + t²*P2
+    					float u = (1.0f-t);
+    					float tt=u*u;
+    					float ttt=2.0f*t*u;
+    					float tttt=t*t;
+    					float p1 = tmp*tt + (coords[0]*ttt) + (coords[2]*tttt);
+    					float p2 = tmp1*tt + (coords[1]*ttt) + (coords[3]*tttt);
+    					points.add(new Vector3d(p1, p2,0));
+    					//println "SEG_QUADTO "+p1+" and "+p2
+    				}
+    				tmp = coords[2];
+    				tmp1 = coords[3];
+    				points.add(new Vector3d(tmp, tmp1,0));
+    				break;
+    	        case PathIterator.SEG_LINETO:
+    				//println "SEG_LINETO "+coords
+    				tmp = coords[0];
+    				tmp1 = coords[1];
+    	            points.add(new Vector3d(tmp, tmp1,0));
+    	            break;
+    	        case PathIterator.SEG_MOVETO:
+    				
+    	            // move without drawing
+    	            start[0] = tmp  =  coords[0];
+    	            start[1] = tmp1 =  coords[1];
+    				//println "Moving to "+start
+    				points.add(new Vector3d(tmp, tmp1,0));
+    	            break;
+    	        case PathIterator.SEG_CUBICTO:
+    	            for(float t=0.0f;t<=1.05f;t+=0.1f) {
+    	                // p = a0 + a1*t + a2 * tt + a3*ttt;
+    	                float tt=t*t;
+    	                float ttt=tt*t;
+    	                float p1 = tmp + (coords[0]*t) + (coords[2]*tt) + (coords[4]*ttt);
+    	                float p2 = tmp1 + (coords[1]*t) + (coords[3]*tt) + (coords[5]*ttt);
+    	                points.add(new Vector3d(p1, p2,0));
+    					//println "SEG_CUBICTO "+p1+" and "+p2
+    	            }
+    	            tmp = coords[4];
+    	            tmp1 = coords[5];
+    	            break;
+    	
+    			default:
+    				throw new RuntimeException("Unknown iterator type: "+type);
+    	        }
+    	        pi.next();
+    			//println "pi.isDone() "+pi.isDone()
+    	    }
+    	for(int i=0;i<sections.size();i++){
+    		for(CSG h:holes){
+    			try{
+    				if(sections.get(i).touching(h)){
+    					//println "Hole found "
+    					CSG nl = sections.get(i).difference(h);
+    					
+    					sections.set(i,nl);
+    				}
+    			}catch(Exception e){
+    				
+    			}
+    		}
+    		//BowlerStudioController.addCsg(sections.get(i));
+    	}
+    	return sections;
+    }
+    
+    
+}
+
+//return Text.text(10.0, "Hello", new Font("Helvedica", Font.PLAIN, 18));

--- a/src/main/java/eu/mihosoft/vrl/v3d/TextExtrude.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/TextExtrude.java
@@ -131,13 +131,13 @@ public class TextExtrude {
 		subtract.getElements().forEach(this::getPoints);
 
 		// Group exterior polygons with their interior polygons
-		polis.stream().filter(LineSegment::isHole).forEach(hole -> {
-			polis.stream().filter(poly -> !poly.isHole())
-					.filter(poly -> !((Path) Shape.intersect(poly.getPath(), hole.getPath())).getElements().isEmpty())
-					.filter(poly -> poly.getPath().contains(new Point2D(hole.getOrigen().x, hole.getOrigen().y)))
-					.forEach(poly -> poly.addHole(hole));
-		});
-		polis.removeIf(LineSegment::isHole);
+//		polis.stream().filter(LineSegment::isHole).forEach(hole -> {
+//			polis.stream().filter(poly -> !poly.isHole())
+//					.filter(poly -> !((Path) Shape.intersect(poly.getPath(), hole.getPath())).getElements().isEmpty())
+//					.filter(poly -> poly.getPath().contains(new Point2D(hole.getOrigen().x, hole.getOrigen().y)))
+//					.forEach(poly -> poly.addHole(hole));
+//		});
+		//polis.removeIf(LineSegment::isHole);
 		
 		for (int i = 0; i < sections.size(); i++) {
 			for (CSG h : holes) {
@@ -187,16 +187,7 @@ public class TextExtrude {
 	    
 	    private void getPoints(PathElement elem){
 	        if(elem instanceof MoveTo){
-	        	points.remove(points.size() - 1);
-				points.remove(points.size() - 1);
-				boolean hole = !Extrude.isCCW(Polygon.fromPoints(points));
-				CSG newLetter = Extrude.points(new Vector3d(0, 0, dir), points);
-
-				if (!hole)
-					sections.add(newLetter);
-				else
-					holes.add(newLetter);
-	            points=new ArrayList<>();
+	        	loadPoints();
 	            p0=new Vector3d((float)((MoveTo)elem).getX(),(float)((MoveTo)elem).getY(),0f);
 	            points.add(p0);
 	        } else if(elem instanceof LineTo){
@@ -220,7 +211,24 @@ public class TextExtrude {
 	                line.setOrigen(p0);
 	                polis.add(line);
 	            }
+	            loadPoints();
+	            
 	        } 
+	    }
+	    
+	    private void loadPoints(){
+        	if(points.size()>4){
+	        	points.remove(points.size() - 1);
+				//points.remove(points.size() - 1);
+				boolean hole = Extrude.isCCW(Polygon.fromPoints(points));
+				CSG newLetter = Extrude.points(new Vector3d(0, 0, dir), points);
+
+				if (!hole)
+					sections.add(newLetter);
+				else
+					holes.add(newLetter);
+        	}
+            points=new ArrayList<>();
 	    }
 	    
 	    private Vector3d evalCubicBezier(CubicCurveTo c, Vector3d ini, double t){

--- a/src/main/java/eu/mihosoft/vrl/v3d/TextExtrude.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/TextExtrude.java
@@ -3,9 +3,6 @@ package eu.mihosoft.vrl.v3d;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.sun.javafx.geom.PathIterator;
-
-import javafx.collections.ObservableList;
 import javafx.scene.shape.ClosePath;
 import javafx.scene.shape.CubicCurveTo;
 import javafx.scene.shape.LineTo;
@@ -17,25 +14,12 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.shape.Shape;
 import javafx.scene.text.Font;
 import javafx.scene.text.Text;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.geometry.Point2D;
 import javafx.scene.paint.Color;
-import javafx.scene.shape.ClosePath;
-import javafx.scene.shape.CubicCurveTo;
-import javafx.scene.shape.LineTo;
-import javafx.scene.shape.MoveTo;
-import javafx.scene.shape.Path;
-import javafx.scene.shape.PathElement;
-import javafx.scene.shape.QuadCurveTo;
-import javafx.scene.shape.Rectangle;
-import javafx.scene.shape.Shape;
-import javafx.scene.text.Font;
-import javafx.scene.text.Text;
 
 // TODO: Auto-generated Javadoc
 /**

--- a/src/main/java/eu/mihosoft/vrl/v3d/TextExtrude.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/TextExtrude.java
@@ -14,168 +14,152 @@ import java.util.ArrayList;
  */
 
 public class TextExtrude {
-	private static final String default_font ="FreeSerif" ;
-	
-    /**
-     * Extrudes the specified path (convex or concave polygon without holes or
-     * intersections, specified in CCW) into the specified direction.
-     *
-     * @param dir direction of extrusion
-     * @param text text
-     * @param font font configuration of the text
-     *
-     * @return a CSG object that consists of the extruded polygon
-     */
-    public static ArrayList<CSG> text(double dir, String text, Font font) {
+	private static final String default_font = "FreeSerif";
 
-    	String default_font ="FreeSerif" ;
-    	String [] fonts = GraphicsEnvironment
-        					.getLocalGraphicsEnvironment()
-        					.getAvailableFontFamilyNames();
-        	
-        	boolean found = false;
-        	for(String f: fonts){
-        		if(f.contentEquals(font.getFontName())){
-        			found=true;
-        			
-        		}
-        	}
-        	if(! found){
-        		for(String f: fonts){
-    	    		
-        			System.out.println( f);
-    	    		
-    	    	}
-        		System.out.println("Font not found! "+font.getFontName() +" using "+default_font);
-        		font = new Font(default_font, font.getStyle(), font.getSize());
-        	}
-    	FontRenderContext frc = new FontRenderContext(null,(boolean)true,(boolean)true);
-    	TextLayout textLayout = new TextLayout(text, font, frc);
-    	Shape s = textLayout.getOutline(null);
-    	
-    	PathIterator pi = s.getPathIterator(null);
-    	ArrayList<Vector3d> points = new ArrayList<Vector3d>();
-    	
-    	CSG stringOut = new Sphere(2).toCSG();
-    	int connectorDepth = 10;
-    	
-    	float [] coords = new float[6];
-    	float [] start = new float[6];
-    	
-    	ArrayList<CSG> sections = new ArrayList<CSG>();
-    	ArrayList<CSG> holes = new ArrayList<CSG>();
-    	
-    	float tmp=0,tmp1=0;
-    	//BowlerStudioController.setCsg(null,null);
-    	  while(pi.isDone() == (boolean)false  ) {
-    		  	coords = new float[6];
-    	        int type = pi.currentSegment(coords);
-    	        switch(type) {
-    	        case PathIterator.SEG_CLOSE:
-    				//points.add(new Vector3d(tmp, tmp1 ,0));
-    				points.add(new Vector3d(start[0], start[1],0));
-    				
-    				if(points.size()>3){
-    					//println "Adding "+points
-    					try{
-    						//println "{"
-    						for(Vector3d v:points){
-    							//Cube nl= new Cube(1);
-    							//nl.setCenter(v);
-    							//BowlerStudioController.addCsg(nl.toCSG());
-    							//ThreadUtil.wait(200)
-    							//println "new Vector3d("+v.x+","+v.y+","+v.z+"),"
-    						}
-    						points.remove(points.size()-1);
-    						points.remove(points.size()-1);
-    						boolean hole = !Extrude.isCCW(Polygon.fromPoints(points));
-    						CSG newLetter = Extrude.points(new Vector3d(0, 0, connectorDepth), points);
-    						//ThreadUtil.wait(5000)
-    						//Color c =new Color(Math.random(),Math.random(),Math.random(),1);
-    						//newLetter.setColor(c);
-    						if(!hole)
-    							sections.add(newLetter);
-    						else
-    							holes.add(newLetter);
-    						//ThreadUtil.wait(10)
-    						//stringOut = new Sphere(2).toCSG();
-    						//return stringOut;
-    					}catch(NullPointerException e){
-    						e.printStackTrace();
-    					}
-    				}
-    	            points = new ArrayList<Vector3d>();
-    	            break;
-    			case PathIterator.SEG_QUADTO:
-    				//println "SEG_QUADTO from ( "+coords[0]+" , "+coords[1]+" ) to ( "+coords[2]+" , "+coords[3]+" )";
-    				for(float t=0.05f;t<=1.0f;t+=0.05f) {
-    					//(1-t)²*P0 + 2t*(1-t)*P1 + t²*P2
-    					float u = (1.0f-t);
-    					float tt=u*u;
-    					float ttt=2.0f*t*u;
-    					float tttt=t*t;
-    					float p1 = tmp*tt + (coords[0]*ttt) + (coords[2]*tttt);
-    					float p2 = tmp1*tt + (coords[1]*ttt) + (coords[3]*tttt);
-    					points.add(new Vector3d(p1, p2,0));
-    					//println "SEG_QUADTO "+p1+" and "+p2
-    				}
-    				tmp = coords[2];
-    				tmp1 = coords[3];
-    				points.add(new Vector3d(tmp, tmp1,0));
-    				break;
-    	        case PathIterator.SEG_LINETO:
-    				//println "SEG_LINETO "+coords
-    				tmp = coords[0];
-    				tmp1 = coords[1];
-    	            points.add(new Vector3d(tmp, tmp1,0));
-    	            break;
-    	        case PathIterator.SEG_MOVETO:
-    				
-    	            // move without drawing
-    	            start[0] = tmp  =  coords[0];
-    	            start[1] = tmp1 =  coords[1];
-    				//println "Moving to "+start
-    				points.add(new Vector3d(tmp, tmp1,0));
-    	            break;
-    	        case PathIterator.SEG_CUBICTO:
-    	            for(float t=0.0f;t<=1.05f;t+=0.1f) {
-    	                // p = a0 + a1*t + a2 * tt + a3*ttt;
-    	                float tt=t*t;
-    	                float ttt=tt*t;
-    	                float p1 = tmp + (coords[0]*t) + (coords[2]*tt) + (coords[4]*ttt);
-    	                float p2 = tmp1 + (coords[1]*t) + (coords[3]*tt) + (coords[5]*ttt);
-    	                points.add(new Vector3d(p1, p2,0));
-    					//println "SEG_CUBICTO "+p1+" and "+p2
-    	            }
-    	            tmp = coords[4];
-    	            tmp1 = coords[5];
-    	            break;
-    	
-    			default:
-    				throw new RuntimeException("Unknown iterator type: "+type);
-    	        }
-    	        pi.next();
-    			//println "pi.isDone() "+pi.isDone()
-    	    }
-    	for(int i=0;i<sections.size();i++){
-    		for(CSG h:holes){
-    			try{
-    				if(sections.get(i).touching(h)){
-    					//println "Hole found "
-    					CSG nl = sections.get(i).difference(h);
-    					
-    					sections.set(i,nl);
-    				}
-    			}catch(Exception e){
-    				
-    			}
-    		}
-    		//BowlerStudioController.addCsg(sections.get(i));
-    	}
-    	return sections;
-    }
-    
-    
+	/**
+	 * Extrudes the specified path (convex or concave polygon without holes or
+	 * intersections, specified in CCW) into the specified direction.
+	 *
+	 * @param dir
+	 *            direction of extrusion
+	 * @param text
+	 *            text
+	 * @param font
+	 *            font configuration of the text
+	 *
+	 * @return a CSG object that consists of the extruded polygon
+	 */
+	public static ArrayList<CSG> text(double dir, String text, Font font) {
+
+		String default_font = "FreeSerif";
+		String[] fonts = GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames();
+
+		boolean found = false;
+		for (String f : fonts) {
+			if (f.contentEquals(font.getFontName())) {
+				found = true;
+
+			}
+		}
+		if (!found) {
+			for (String f : fonts) {
+
+				System.out.println(f);
+
+			}
+			System.out.println("Font not found! " + font.getFontName() + " using " + default_font);
+			font = new Font(default_font, font.getStyle(), font.getSize());
+		}
+		FontRenderContext frc = new FontRenderContext(null, (boolean) true, (boolean) true);
+		TextLayout textLayout = new TextLayout(text, font, frc);
+		Shape s = textLayout.getOutline(null);
+
+		PathIterator pi = s.getPathIterator(null);
+		ArrayList<Vector3d> points = new ArrayList<Vector3d>();
+
+		int connectorDepth = 10;
+
+		float[] coords = new float[6];
+		float[] start = new float[6];
+
+		ArrayList<CSG> sections = new ArrayList<CSG>();
+		ArrayList<CSG> holes = new ArrayList<CSG>();
+
+		float tmp = 0, tmp1 = 0;
+		while (pi.isDone() == (boolean) false) {
+			coords = new float[6];
+			int type = pi.currentSegment(coords);
+			switch (type) {
+			case PathIterator.SEG_CLOSE:
+				points.add(new Vector3d(start[0], start[1], 0));
+
+				if (points.size() > 3) {
+					try {
+						points.remove(points.size() - 1);
+						points.remove(points.size() - 1);
+						boolean hole = !Extrude.isCCW(Polygon.fromPoints(points));
+						CSG newLetter = Extrude.points(new Vector3d(0, 0, connectorDepth), points);
+
+						if (!hole)
+							sections.add(newLetter);
+						else
+							holes.add(newLetter);
+						// ThreadUtil.wait(10)
+						// stringOut = new Sphere(2).toCSG();
+						// return stringOut;
+					} catch (NullPointerException e) {
+						e.printStackTrace();
+					}
+				}
+				points = new ArrayList<Vector3d>();
+				break;
+			case PathIterator.SEG_QUADTO:
+				// println "SEG_QUADTO from ( "+coords[0]+" , "+coords[1]+" ) to
+				// ( "+coords[2]+" , "+coords[3]+" )";
+				for (float t = 0.05f; t <= 1.0f; t += 0.05f) {
+					// (1-t)²*P0 + 2t*(1-t)*P1 + t²*P2
+					float u = (1.0f - t);
+					float tt = u * u;
+					float ttt = 2.0f * t * u;
+					float tttt = t * t;
+					float p1 = tmp * tt + (coords[0] * ttt) + (coords[2] * tttt);
+					float p2 = tmp1 * tt + (coords[1] * ttt) + (coords[3] * tttt);
+					points.add(new Vector3d(p1, p2, 0));
+					// println "SEG_QUADTO "+p1+" and "+p2
+				}
+				tmp = coords[2];
+				tmp1 = coords[3];
+				points.add(new Vector3d(tmp, tmp1, 0));
+				break;
+			case PathIterator.SEG_LINETO:
+				// println "SEG_LINETO "+coords
+				tmp = coords[0];
+				tmp1 = coords[1];
+				points.add(new Vector3d(tmp, tmp1, 0));
+				break;
+			case PathIterator.SEG_MOVETO:
+
+				// move without drawing
+				start[0] = tmp = coords[0];
+				start[1] = tmp1 = coords[1];
+				// println "Moving to "+start
+				points.add(new Vector3d(tmp, tmp1, 0));
+				break;
+			case PathIterator.SEG_CUBICTO:
+				for (float t = 0.0f; t <= 1.05f; t += 0.1f) {
+					// p = a0 + a1*t + a2 * tt + a3*ttt;
+					float tt = t * t;
+					float ttt = tt * t;
+					float p1 = tmp + (coords[0] * t) + (coords[2] * tt) + (coords[4] * ttt);
+					float p2 = tmp1 + (coords[1] * t) + (coords[3] * tt) + (coords[5] * ttt);
+					points.add(new Vector3d(p1, p2, 0));
+					// println "SEG_CUBICTO "+p1+" and "+p2
+				}
+				tmp = coords[4];
+				tmp1 = coords[5];
+				break;
+
+			default:
+				throw new RuntimeException("Unknown iterator type: " + type);
+			}
+			pi.next();
+			// println "pi.isDone() "+pi.isDone()
+		}
+		for (int i = 0; i < sections.size(); i++) {
+			for (CSG h : holes) {
+				try {
+					if (sections.get(i).touching(h)) {
+						// println "Hole found "
+						CSG nl = sections.get(i).difference(h);
+
+						sections.set(i, nl);
+					}
+				} catch (Exception e) {
+
+				}
+			}
+		}
+		return sections;
+	}
+
 }
-
-//return Text.text(10.0, "Hello", new Font("Helvedica", Font.PLAIN, 18));

--- a/src/test/java/eu/mihosoft/vrl/v3d/textTest.java
+++ b/src/test/java/eu/mihosoft/vrl/v3d/textTest.java
@@ -1,0 +1,24 @@
+package eu.mihosoft.vrl.v3d;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+import javafx.scene.text.Font;
+
+public class textTest {
+
+	@Test
+	public void test() throws IOException {
+		TextExtrude.text(10.0, "Hello", new Font("Helvedica",  18));
+		TextExtrude.text(10.0, "Hello World!", new Font("Times New Roman", 18));
+		
+		Text3d text = new Text3d("Hello world", 10);
+		FileUtil.write(Paths.get("exampleText.stl"),
+				text.toCSG().toStlString());
+	}
+
+}


### PR DESCRIPTION
This version of text extrude uses only JavaFX API (ported code from https://github.com/FXyz/FXyz/blob/master/FXyz-Core/src/main/java/org/fxyz3d/shapes/primitives/helper/Text3DHelper.java ) 

By changing the point datatype to vector3d, and  adding the extrude features in, the code to generate text from FXyz3d has been ported into JCSG. This should be a 1:1 version of the original text extrude feature using the deep library code pulled to the surface in JCSG, preventing the circular dependency. This should also resolve the merge issue with AWT being incompatible with android. 